### PR TITLE
Add multi-site pages for ZUP

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,9 +2,11 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>ZUP</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Fira+Sans:wght@400;700&family=Inter:wght@400;700&display=swap" rel="stylesheet">
   </head>
   <body>
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.1.1",
-        "react-dom": "^19.1.1"
+        "react-dom": "^19.1.1",
+        "react-router-dom": "^7.8.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.32.0",
@@ -1968,6 +1969,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2971,6 +2981,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.8.0.tgz",
+      "integrity": "sha512-r15M3+LHKgM4SOapNmsH3smAizWds1vJ0Z9C4mWaKnT9/wD7+d/0jYcj6LmOvonkrO4Rgdyp4KQ/29gWN2i1eg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.8.0.tgz",
+      "integrity": "sha512-ntInsnDVnVRdtSu6ODmTQ41cbluak/ENeTif7GBce0L6eztFg6/e1hXAysFQI8X25C8ipKmT9cClbJwxx3Kaqw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.8.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -3071,6 +3119,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "react-router-dom": "^7.8.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.32.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,35 +1,20 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import { Routes, Route } from 'react-router-dom'
+import ZupHome from './pages/ZupHome'
+import DispatchHome from './pages/dispatch/Home'
+import DispatchAbout from './pages/dispatch/About'
+import DispatchTerms from './pages/dispatch/Terms'
+import DispatchPrivacy from './pages/dispatch/Privacy'
+import MediaComingSoon from './pages/media/ComingSoon'
 
-function App() {
-  const [count, setCount] = useState(0)
-
+export default function App() {
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    <Routes>
+      <Route path="/" element={<ZupHome />} />
+      <Route path="/dispatch" element={<DispatchHome />} />
+      <Route path="/dispatch/about" element={<DispatchAbout />} />
+      <Route path="/dispatch/terms" element={<DispatchTerms />} />
+      <Route path="/dispatch/privacy" element={<DispatchPrivacy />} />
+      <Route path="/media" element={<MediaComingSoon />} />
+    </Routes>
   )
 }
-
-export default App

--- a/src/components/FlippingCard.tsx
+++ b/src/components/FlippingCard.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+
+interface Props {
+  front: React.ReactNode
+  back: React.ReactNode
+  direction?: 'left' | 'right'
+}
+
+export default function FlippingCard({ front, back, direction = 'left' }: Props) {
+  return (
+    <div className={`flip-card ${direction === 'right' ? 'right' : ''}`}>
+      <div className="flip-inner">
+        <div className="flip-front">{front}</div>
+        <div className="flip-back">{back}</div>
+      </div>
+    </div>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,68 +1,24 @@
-:root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
+@import url('https://fonts.googleapis.com/css2?family=Fira+Sans:wght@400;700&family=Inter:wght@400;700&display=swap');
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
+html, body, #root {
+  margin: 0;
+  padding: 0;
+  height: 100%;
 }
 
 body {
-  margin: 0;
+  font-family: 'Inter', 'Fira Sans', sans-serif;
+  background-color: #0f0f0f;
+  color: #ffffff;
+}
+
+/* generic utility classes */
+.text-accent {
+  color: #FFD500;
+}
+
+.center {
   display: flex;
-  place-items: center;
-  min-width: 320px;
-  min-height: 100vh;
-}
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+  align-items: center;
+  justify-content: center;
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import App from './App.tsx'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </StrictMode>,
 )

--- a/src/pages/ZupHome.tsx
+++ b/src/pages/ZupHome.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react'
+import FlippingCard from '../components/FlippingCard'
+import '../styles/zup.css'
+import mediaLogo from '../assets/logos/logo_zup_media.png'
+import dispatchLogo from '../assets/logos/logo_zup_dispatch.png'
+
+const words = [
+  'platforms',
+  'brands',
+  'experiences',
+  'stories',
+  'interfaces',
+  'tools',
+  'campaigns',
+  'products'
+]
+
+export default function ZupHome() {
+  const [index, setIndex] = useState(0)
+
+  useEffect(() => {
+    const id = setInterval(
+      () => setIndex((i) => (i + 1) % words.length),
+      2500
+    )
+    return () => clearInterval(id)
+  }, [])
+
+  return (
+    <div className="zup-home">
+      <h1 className="hero-title">
+        We build <span className="changing-word">{words[index]}</span> that matter.
+      </h1>
+      <div className="card-container">
+        <FlippingCard
+          front={<img src={mediaLogo} alt="ZUP! MEDIA" />}
+          back={<span>Marketing that converts. For brands that matter.</span>}
+          direction="left"
+        />
+        <FlippingCard
+          front={<img src={dispatchLogo} alt="ZUP! DISPATCH" />}
+          back={<span>One app. All taxis. Across Romania.</span>}
+          direction="right"
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/pages/dispatch/About.tsx
+++ b/src/pages/dispatch/About.tsx
@@ -1,0 +1,43 @@
+import '../../styles/dispatch.css'
+
+export default function DispatchAbout() {
+  return (
+    <div className="dispatch-page">
+      <h1>About ZUP! Dispatch</h1>
+      <section>
+        <h2>Mission &amp; Vision</h2>
+        <p>
+          Built to modernize Romania’s taxi infrastructure with a transparent, tech-first and legally compliant platform.
+        </p>
+      </section>
+      <section>
+        <h2>Founders &amp; Evolution</h2>
+        <p>
+          From a pilot in Piatra Neamț, we are now scaling nationwide with over 100 drivers onboard.
+        </p>
+      </section>
+      <section>
+        <h2>Achievements</h2>
+        <ul className="dispatch-list">
+          <li>Awards: CONAF, Arena Urşilor</li>
+          <li>Endorsements from local entrepreneurs &amp; investors</li>
+        </ul>
+      </section>
+      <section>
+        <h2>Core Values</h2>
+        <ul className="dispatch-list">
+          <li>Safety</li>
+          <li>Transparency</li>
+          <li>Inclusivity</li>
+          <li>Innovation</li>
+        </ul>
+      </section>
+      <section>
+        <h2>Team Credibility</h2>
+        <p>
+          Our team brings expertise in UI/UX, marketing through ZUP! Media, and proven business scalability.
+        </p>
+      </section>
+    </div>
+  )
+}

--- a/src/pages/dispatch/Home.tsx
+++ b/src/pages/dispatch/Home.tsx
@@ -1,0 +1,71 @@
+import '../../styles/dispatch.css'
+
+export default function DispatchHome() {
+  return (
+    <div className="dispatch-page">
+      <h1>Romania’s first national taxi dispatch app</h1>
+      <p>Real licensed taxis. Transparent pricing. Instant booking.</p>
+      <section>
+        <h2>Why Choose ZUP! Dispatch</h2>
+        <ul className="dispatch-list">
+          <li>Nationwide coverage of licensed taxis</li>
+          <li>Instant booking via mobile app</li>
+          <li>Fair fares linked to official taximeters (no surge pricing)</li>
+          <li>Fleet management &amp; analytics for operators</li>
+        </ul>
+      </section>
+      <section>
+        <h2>Features / Smart Ride Options</h2>
+        <ul className="dispatch-list">
+          <li><strong>ZUP!</strong> – Standard ride from nearest taxi station</li>
+          <li><strong>ZIP!</strong> – Premium comfort ride in cars made after 2017</li>
+          <li><strong>ZAP!</strong> – Fast pickup from your current location</li>
+          <li><strong>ZUP! NOW</strong> – Instant booking by tapping a vehicle on the map</li>
+        </ul>
+      </section>
+      <section>
+        <h2>Real‑World Validation</h2>
+        <ul className="dispatch-list">
+          <li>2nd place at CONAF National Business Competition</li>
+          <li>3rd place at Arena Urşilor Pre‑Accelerator</li>
+        </ul>
+      </section>
+      <section>
+        <h2>Driver Standards</h2>
+        <ul className="dispatch-list">
+          <li>Minimum 12 grades, bac diploma, ≥3 years driving experience</li>
+          <li>Clean record, background checks, high hygiene standards</li>
+        </ul>
+      </section>
+      <section>
+        <h2>Supported Cities</h2>
+        <p>
+          Live in <strong>Piatra Neamț</strong>, expanding soon to <strong>Iași, Cluj, Brașov, Bucharest</strong>
+        </p>
+      </section>
+      <section>
+        <h2>FAQ (Summary)</h2>
+        <ul className="dispatch-list">
+          <li>What is ZUP?</li>
+          <li>How is ZUP different from Uber/Bolt?</li>
+          <li>Payment methods (Card, Apple Pay, Google Pay, Cash)</li>
+          <li>How to join as a driver or fleet owner</li>
+          <li>How ZIP!, ZAP!, ZUP! NOW work</li>
+          <li>Supported cities</li>
+        </ul>
+      </section>
+      <section id="newsletter">
+        <h2>Stay updated and receive bonuses when we launch!</h2>
+        <form className="news-form">
+          <input type="email" placeholder="Your email" required />
+          <button type="submit">Sign up</button>
+        </form>
+      </section>
+      <footer style={{ marginTop: '2rem', textAlign: 'center', fontSize: '0.9rem' }}>
+        <a href="/dispatch/terms">Terms</a> | <a href="/dispatch/privacy">Privacy</a> |{' '}
+        <a href="/dispatch/privacy#cookies">Cookies</a>
+        <div style={{ marginTop: '0.5rem' }}>© 2025 ZUP!</div>
+      </footer>
+    </div>
+  )
+}

--- a/src/pages/dispatch/Privacy.tsx
+++ b/src/pages/dispatch/Privacy.tsx
@@ -1,0 +1,21 @@
+import '../../styles/dispatch.css'
+
+export default function DispatchPrivacy() {
+  return (
+    <div className="dispatch-page">
+      <h1>Privacy Policy</h1>
+      <section>
+        <p>
+          We value your privacy and collect only the data necessary to operate the ZUP! Dispatch platform.
+        </p>
+        <ul className="dispatch-list">
+          <li><strong>Data collected:</strong> phone, email, ride route and payment details.</li>
+          <li><strong>Use:</strong> scheduling rides, billing, and aggregated analytics.</li>
+          <li><strong>Legal compliance:</strong> integration with ANAF taxation systems and full GDPR adherence.</li>
+          <li><strong>Retention:</strong> information is kept only as long as required for legal or operational purposes and can be deleted upon request.</li>
+          <li><strong>Third‑party integrations:</strong> mapping, analytics and payment gateways process data under their own policies.</li>
+        </ul>
+      </section>
+    </div>
+  )
+}

--- a/src/pages/dispatch/Terms.tsx
+++ b/src/pages/dispatch/Terms.tsx
@@ -1,0 +1,20 @@
+import '../../styles/dispatch.css'
+
+export default function DispatchTerms() {
+  return (
+    <div className="dispatch-page">
+      <h1>Terms &amp; Conditions</h1>
+      <section>
+        <p>
+          ZUP! Dispatch connects riders with licensed taxi operators across Romania. By using our services you agree to the following terms:
+        </p>
+        <ul className="dispatch-list">
+          <li>Users must provide accurate contact details and comply with local transportation laws.</li>
+          <li>Rides are fulfilled by independent, licensed drivers and are subject to their availability.</li>
+          <li>Fares are calculated using official taximeters with transparent pricing; no surge pricing is applied.</li>
+          <li>Payments and any refund requests must follow the policies of the taxi operator and applicable law.</li>
+        </ul>
+      </section>
+    </div>
+  )
+}

--- a/src/pages/media/ComingSoon.tsx
+++ b/src/pages/media/ComingSoon.tsx
@@ -1,0 +1,25 @@
+import '../../styles/media.css'
+
+export default function MediaComingSoon() {
+  return (
+    <div className="media-page">
+      <h1>ZUP! Media is coming soon.</h1>
+      <p>But we're already working with bold brands. Get in touch below.</p>
+      <form
+        className="media-form"
+        action="https://formsubmit.co/contact@zup.digital"
+        method="POST"
+      >
+        <input type="text" name="name" placeholder="Your full name" required />
+        <input type="text" name="subject" placeholder="Project topic or idea" required />
+        <textarea
+          name="message"
+          placeholder="Tell us what you need..."
+          rows={5}
+          required
+        ></textarea>
+        <button type="submit">Send message</button>
+      </form>
+    </div>
+  )
+}

--- a/src/styles/dispatch.css
+++ b/src/styles/dispatch.css
@@ -1,0 +1,48 @@
+.dispatch-page {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+  line-height: 1.6;
+}
+
+.dispatch-page h1 {
+  color: #FFD500;
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+.dispatch-page h2 {
+  color: #FFD500;
+  margin-top: 2rem;
+}
+
+.dispatch-list {
+  list-style: disc;
+  padding-left: 1.5rem;
+}
+
+.news-form {
+  margin-top: 1rem;
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.news-form input {
+  flex: 1;
+  padding: 0.5rem;
+  border-radius: 4px;
+  border: 1px solid #FFD500;
+  background: #1a1a1a;
+  color: #fff;
+}
+
+.news-form button {
+  padding: 0.5rem 1rem;
+  border: none;
+  background: #FFD500;
+  color: #000;
+  font-weight: 700;
+  border-radius: 4px;
+  cursor: pointer;
+}

--- a/src/styles/media.css
+++ b/src/styles/media.css
@@ -1,0 +1,46 @@
+.media-page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 2rem 1rem;
+}
+
+.media-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: 100%;
+  max-width: 400px;
+  margin-top: 2rem;
+}
+
+.media-form input,
+.media-form textarea {
+  padding: 0.75rem;
+  background: #1a1a1a;
+  border: 1px solid #FFD500;
+  border-radius: 8px;
+  color: #fff;
+}
+
+.media-form input:focus,
+.media-form textarea:focus {
+  outline: none;
+  box-shadow: 0 0 8px #FFD500;
+}
+
+.media-form button {
+  padding: 0.75rem;
+  background: #FFD500;
+  border: none;
+  border-radius: 8px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.media-form button:hover {
+  box-shadow: 0 0 12px #FFD500;
+}

--- a/src/styles/zup.css
+++ b/src/styles/zup.css
@@ -1,0 +1,83 @@
+.zup-home {
+  position: relative;
+  min-height: 100vh;
+  text-align: center;
+  overflow: hidden;
+  padding: 2rem 1rem;
+}
+
+.zup-home::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 50% 50%, rgba(255,213,0,0.15), transparent 70%);
+  animation: pulse 6s ease-in-out infinite alternate;
+  z-index: -1;
+}
+
+@keyframes pulse {
+  from {transform: scale(1);} 
+  to {transform: scale(1.2);} 
+}
+
+.hero-title {
+  font-size: clamp(2rem, 5vw, 4rem);
+  font-weight: 700;
+}
+
+.changing-word {
+  color: #FFD500;
+}
+
+.card-container {
+  margin-top: 3rem;
+  display: flex;
+  gap: 2rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.flip-card {
+  width: 220px;
+  height: 220px;
+  perspective: 1000px;
+}
+
+.flip-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  transition: transform 0.4s;
+  transform-style: preserve-3d;
+}
+
+.flip-card:hover .flip-inner {
+  transform: rotateY(180deg);
+}
+
+.flip-card.right:hover .flip-inner {
+  transform: rotateY(-180deg);
+}
+
+.flip-front, .flip-back {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  border: 2px solid #FFD500;
+  border-radius: 12px;
+  backface-visibility: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #1a1a1a;
+}
+
+.flip-front img {
+  max-width: 70%;
+}
+
+.flip-back {
+  transform: rotateY(180deg);
+  padding: 1rem;
+  color: #fff;
+}


### PR DESCRIPTION
## Summary
- implement landing portal with rotating words and flipping cards
- add Dispatch subsite with home, about, terms, and privacy pages
- create Media coming-soon page with contact form

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a0ee803e08324ad15d3ab8ab4bf01