### PR TITLE
docs: add setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,30 @@
 
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
 
+## Setup
+
+1. Install dependencies:
+
+   ```bash
+   npm install
+   ```
+
+   Make sure all required packages such as `react-router-dom` are installed before attempting to build.
+
+2. Build the project:
+
+   ```bash
+   npm run build
+   ```
+
+3. Start the development server:
+
+   ```bash
+   npm run dev
+   ```
+
+   Additional scripts like `npm run lint`, `npm test`, and `npm run preview` are also available.
+
 Currently, two official plugins are available:
 
 - [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh


### PR DESCRIPTION
## Summary
- document project setup with npm install, build, and dev scripts
- note that dependencies such as react-router-dom must be installed before building

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a13140f548324b590b9e0076a166b