### PR TITLE
Make home page cards navigate to media and dispatch

### DIFF
--- a/src/pages/ZupHome.tsx
+++ b/src/pages/ZupHome.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
 import FlippingCard from '../components/FlippingCard'
 import '../styles/zup.css'
 import mediaLogo from '../assets/logos/logo_zup_media.png'
@@ -32,16 +33,20 @@ export default function ZupHome() {
         We build <span className="changing-word">{words[index]}</span> that matter.
       </h1>
       <div className="card-container">
-        <FlippingCard
-          front={<img src={mediaLogo} alt="ZUP! MEDIA" />}
-          back={<span>Marketing that converts. For brands that matter.</span>}
-          direction="left"
-        />
-        <FlippingCard
-          front={<img src={dispatchLogo} alt="ZUP! DISPATCH" />}
-          back={<span>One app. All taxis. Across Romania.</span>}
-          direction="right"
-        />
+        <Link to="/media" className="card-link">
+          <FlippingCard
+            front={<img src={mediaLogo} alt="ZUP! MEDIA" />}
+            back={<span>Marketing that converts. For brands that matter.</span>}
+            direction="left"
+          />
+        </Link>
+        <Link to="/dispatch" className="card-link">
+          <FlippingCard
+            front={<img src={dispatchLogo} alt="ZUP! DISPATCH" />}
+            back={<span>One app. All taxis. Across Romania.</span>}
+            direction="right"
+          />
+        </Link>
       </div>
     </div>
   )

--- a/src/styles/zup.css
+++ b/src/styles/zup.css
@@ -37,6 +37,10 @@
   flex-wrap: wrap;
 }
 
+.card-link {
+  display: inline-block;
+}
+
 .flip-card {
   width: 220px;
   height: 220px;


### PR DESCRIPTION
## Summary
- Wrap home page cards with router links so Zup Media points to `/media` and Zup Dispatch to `/dispatch`
- Add styling for link wrappers to preserve card layout

## Testing
- `npm run lint`
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a06dab69448324b1d6a11f6be006bd